### PR TITLE
Add an index-like resources overview

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"text/template"
@@ -194,7 +195,49 @@ func convertPull(db *bbolt.DB, flags *atlantisFlags, pull models.PullStatus) (ui
 		}
 		res.Stacks = append(res.Stacks, uiPrj)
 	}
+	res.ResourcesIndex = buildResourcesIndex(res.Stacks)
+
 	return res, nil
+}
+
+func buildResourcesIndex(stacks []uiStack) []uiResourceIndex {
+	index := make(map[string]map[string]struct{})
+
+	re := regexp.MustCompile(`\[[^]]*]`)
+	populateIndex := func(path string, diffs []uiDiff) {
+		for _, diff := range diffs {
+			maskedAddr := re.ReplaceAllString(diff.Address, "")
+			if _, ok := index[maskedAddr]; !ok {
+				index[maskedAddr] = make(map[string]struct{})
+			}
+			index[maskedAddr][path] = struct{}{}
+		}
+	}
+
+	for _, stack := range stacks {
+		if stack.PlanError || stack.LockURL != "" {
+			continue
+		}
+
+		populateIndex(stack.Path, stack.ResourceDiffs)
+		populateIndex(stack.Path, stack.DriftDiffs)
+		populateIndex(stack.Path, stack.Moves)
+	}
+
+	var res []uiResourceIndex
+	for address, stackSet := range index {
+		var stackList []string
+		for path := range stackSet {
+			stackList = append(stackList, path)
+		}
+
+		res = append(res, uiResourceIndex{
+			Address: address,
+			Stacks:  stackList,
+		})
+	}
+
+	return res
 }
 
 func convertStack(pull models.PullStatus, prj models.ProjectStatus, locks map[string]*models.ProjectLock, logURLs map[string]string, atlantisURL string) (uiStack, error) {
@@ -549,7 +592,8 @@ type uiData struct {
 	PRNum  int    `json:"pr_num"`
 	PRURL  string `json:"pr_url"`
 
-	Stacks []uiStack `json:"stacks"`
+	Stacks         []uiStack         `json:"stacks"`
+	ResourcesIndex []uiResourceIndex `json:"resources_index"`
 }
 
 type uiStack struct {
@@ -588,6 +632,11 @@ type uiDiff struct {
 
 	// ImportID is set for imports, action might be "no-op" in this case
 	ImportID string `json:"import_id,omitempty"`
+}
+
+type uiResourceIndex struct {
+	Address string   `json:"address"`
+	Stacks  []string `json:"stacks"`
 }
 
 func main() {

--- a/ui/index.html
+++ b/ui/index.html
@@ -52,6 +52,10 @@
         </button>
     </div>
 
+    <div class="accordion">
+        <Resources ref="resourcesIndex" :resources-index="pull.resourcesIndex"></Resources>
+    </div>
+
     <div class="accordion" v-for="item in sortedStacks" >
         <Stack ref="stacks" :data="item" :show="show" :executable-name="pull.executableName"></Stack>
     </div>
@@ -65,10 +69,11 @@
 <script type="module">
     import Stack from './stack.js'
     import Stats from './stats.js'
+    import Resources from './resources.js'
     import { Pull } from './models.js'
 
     const App = {
-        components: { Stack, Stats },
+        components: { Stack, Stats, Resources },
         data() {
             return {
                 loading: true,

--- a/ui/models.js
+++ b/ui/models.js
@@ -10,6 +10,10 @@ class Pull {
             this.stacks.push(new Stack(stackRaw))
         }
 
+        this.resourcesIndex = (raw["resources_index"] || [])
+            .map((r) => new ResourceIndex(r))
+            .sort((l, r) => l.address.localeCompare(r.address))
+
         console.log(this)
     }
 
@@ -146,4 +150,18 @@ class Diff {
     }
 }
 
-export { Pull, Stack, Diff }
+class ResourceIndex {
+    constructor(raw) {
+        this.address = raw["address"]
+        this.stacks = (raw["stacks"] || [])
+            .map((s) => sanitize(s))
+            .sort((l, r) => l.localeCompare(r))
+    }
+
+    get addressSanitized() {
+        return sanitize(this.address)
+    }
+}
+
+
+export { Pull, Stack, Diff, ResourceIndex }

--- a/ui/resources.js
+++ b/ui/resources.js
@@ -1,0 +1,101 @@
+export default {
+    props: {
+        resourcesIndex: {
+            type: Array,
+            default: [],
+        }
+    },
+    data() {
+        return {
+            expandedAll: false,
+        }
+    },
+    template: `
+        <div class="accordion-item border rounded mb-4">
+            <span class="accordion-header stack-accordion-header" style="display: flex;">
+                <button id="btn-resources-index" @click="expandIndex" class="accordion-button collapsed">
+                    <span class="me-2" style="font-weight: 500;">Resources Index</span>
+                </button>
+                <button @click="toggleAll" class="btn btn-light btn-sm my-1 ms-1" title="Expand all resources">
+                    <i :class="{
+                        'bi-chevron-expand': !expandedAll,
+                        'bi-chevron-contract': expandedAll,
+                    }"></i>
+                </button>
+            </span>
+            <div id="resources-index-accordion" class="accordion-collapse collapse" data-bs-parent="#accordion">
+                <div class="accordion-body">
+                    <div v-if="resourcesIndex.length > 0" class="accordion">
+                        <div class="accordion-item" v-for="resource in resourcesIndex">
+                            <span class="accordion-header resource-accordion-header" style="display: flex;">
+                                <span @click="copy(resource.address)" class="btn btn-light btn-sm" title="Copy resource address">
+                                    <i class="bi-clipboard"></i>
+                                </span>
+                                <button class="accordion-button accordion-button-light collapsed" data-bs-toggle="collapse"
+                                        :data-bs-target="'#' + resource.addressSanitized">
+                                    <span class="ms-1 hscroll">{{ resource.address }}</span>
+                                    <span class="badge bg-info ms-2">{{ resource.stacks.length }}</span>
+                                </button>
+                            </span>
+                            <div :id="resource.addressSanitized" class="accordion-collapse collapse"
+                                 data-bs-parent="#resource-accordion">
+                                <div class="accordion-body">
+                                    <ul class="mb-0">
+                                        <li v-for="stack in resource.stacks">{{ stack }}</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-else class="alert alert-info">Zero-diff. Remote configuration fully matches code.</div>
+                </div>
+            </div>
+        </div>
+    `,
+    methods: {
+        copy(s) {
+            navigator.clipboard.writeText(s)
+        },
+        toggleAll() {
+            if (this.expandedAll) {
+                this.collapseAll()
+            } else {
+                this.expandAll()
+            }
+        },
+        expandIndex() {
+            const btn = document.getElementById('btn-resources-index')
+            const container = document.getElementById('resources-index-accordion')
+
+            if (btn.classList.contains('collapsed')) {
+                btn.classList.remove('collapsed')
+                container.classList.add('show')
+            } else {
+                btn.classList.add('collapsed')
+                container.classList.remove('show')
+                if (this.expandedAll) {
+                    this.collapseAll()
+                }
+            }
+        },
+        expandAll() {
+            const btn = document.getElementById('btn-resources-index')
+            if (btn.classList.contains('collapsed')) {
+                this.expandIndex()
+            }
+
+            document.querySelectorAll('#resources-index-accordion .accordion-button').forEach(
+                (el) => el.classList.remove('collapsed'))
+            document.querySelectorAll('#resources-index-accordion .accordion-collapse').forEach(
+                (el) => el.classList.add('show'))
+            this.expandedAll = true
+        },
+        collapseAll() {
+            document.querySelectorAll('#resources-index-accordion .accordion-button').forEach(
+                (el) => el.classList.add('collapsed'))
+            document.querySelectorAll('#resources-index-accordion .accordion-collapse').forEach(
+                (el) => el.classList.remove('show'))
+            this.expandedAll = false
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an inverted index mapping resources to the stacks where they are changed. This helps to get a high-level overview without diving into individual stacks when many of them are affected.
The section is placed above the stacks section; it is collapsed by default.

<img width="1453" height="747" alt="Screenshot 2026-01-17 at 21 19 00" src="https://github.com/user-attachments/assets/4f195aa7-d114-4940-ad3f-e12fc8ef1e2e" />
